### PR TITLE
Create state directory if necessary

### DIFF
--- a/pladder/bot.py
+++ b/pladder/bot.py
@@ -61,6 +61,7 @@ class PladderBot(ExitStack):
 
     def __init__(self, state_dir):
         super().__init__()
+        os.makedirs(state_dir, exist_ok=True)
         self.state_dir = state_dir
         self.commands = []
         self.register_command("help", self.help)


### PR DESCRIPTION
The command in the readme for a "Quick 'n' Dirty Test Setup" does not work without first creating the test_state directory.
Perhaps always attempting to create it is a good idea?