### PR TITLE
Add an (optional) context for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ that network:
 Set up the configuration file like this:
 
     {
+        "network": "RaekNet",
         "host": "irc.raek.se",
         "port": 6667,
         "nick": "pladder123",

--- a/pladder/cli.py
+++ b/pladder/cli.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import argparse
 import os
 import sys
@@ -28,12 +29,18 @@ def main():
 
 def run_commands(bot, command):
     if command is not None:
-        print(bot.RunCommand(command))
+        print(run_command(bot, command))
     else:
         for line in sys.stdin:
-            print(bot.RunCommand(line.strip()))
+            print(run_command(bot, line.strip()))
 
-            
+def run_command(bot, command):
+    network = 'cli'
+    reply_to = 'cli'
+    sender = 'user'
+    timestamp = datetime.now(timezone.utc).timestamp()
+    return bot.RunCommand(timestamp, network, reply_to, sender, command)
+
 def default_state_dir():
     state_home = os.environ.get("XDG_CONFIG_HOME", os.path.join(os.environ["HOME"], ".config"))
     state_dir = os.path.join(state_home, "pladder-bot")

--- a/pladder/irc/main.py
+++ b/pladder/irc/main.py
@@ -78,9 +78,9 @@ def set_up_dbus(hooks_base_class):
     bot = bus.get("se.raek.PladderBot")
 
     class DbusHooks(hooks_base_class):
-        def on_trigger(self, sender, text):
+        def on_trigger(self, timestamp, network, channel, sender, text):
             try:
-                return bot.RunCommand(text)
+                return bot.RunCommand(timestamp, network, channel, sender.nick, text)
             except GLib.Error as e:
                 logger.error(str(e))
                 return "Oops! Error logged."

--- a/pladder/misc.py
+++ b/pladder/misc.py
@@ -9,10 +9,11 @@ class MiscPlugin(Plugin):
         super().__init__()
         self.bot = bot
         self.misc_cmds = MiscCmds()
-        bot.register_command("kloo+fify", self.kloofify, varargs=True, regex=True)
+        bot.register_command("kloo+fify", self.kloofify, varargs=True, regex=True, contextual=True)
         bot.register_command("comp", self.comp, varargs=True)
 
-    def kloofify(self, command, text):
+    def kloofify(self, context, text):
+        command = context['command']
         for _ in range(command.count("o")-1):
             text = self.misc_cmds.kloofify(text)
         return text


### PR DESCRIPTION
Commands can now register as "contextual", which makes them receive the
context as their first argument.
The context contains a timestamp (seconds since epoch), the network name
(introduced to the pladder-irc config file by this commit), the channel
the command was issued in, the nick of the user who issued the command,
and the name of the command as given.
The command in the context replaces the command argument that was
previously sent to those commands which registered as "regex".