### PR TITLE
Searchlog improvement

### DIFF
--- a/pladder/bot.py
+++ b/pladder/bot.py
@@ -152,9 +152,6 @@ class PladderBot(ExitStack):
             index = int(index)
         except ValueError:
             return "'index' needs to be a number!"
-        if index < 0:
-            # Subtract one from index to ignore the line where the command was issued
-            index -= 1
 
         def format_log_line(index, date, nick, text):
             return '[{}: {} {}: {}]'.format(index, date.strftime('%H:%M'), nick, text)

--- a/pladder/cli.py
+++ b/pladder/cli.py
@@ -40,7 +40,10 @@ def run_command(bot, command):
     reply_to = 'cli'
     sender = 'user'
     timestamp = datetime.now(timezone.utc).timestamp()
-    return bot.RunCommand(timestamp, network, reply_to, sender, command)
+    reply = bot.RunCommand(timestamp, network, reply_to, sender, command)
+    if reply:
+        reply = reply['text']
+    return reply
 
 
 def default_state_dir():

--- a/pladder/irc/client.py
+++ b/pladder/irc/client.py
@@ -13,6 +13,7 @@ Config = namedtuple("Config", "network, host, port, nick, realname, auth, user_m
 AuthConfig = namedtuple("AuthConfig", "system, username, password")
 
 msgsplitter = {}
+commands = {}
 
 class Hooks:
     def on_ready(self):
@@ -52,28 +53,35 @@ def run_client(config, hooks):
             else:
                 reply_to = message.sender.nick
             timestamp = datetime.now(timezone.utc).timestamp()
-            hooks.on_privmsg(timestamp, config.network, reply_to, message.sender, text)
+            reply = None
+            command = None
+            msgpart = None
             if text.startswith(config.trigger_prefix):
                 logger.info("{} -> {} : {}".format(message.sender.nick, target, text))
                 timestamp = datetime.now(timezone.utc).timestamp()
                 text_without_prefix = text[len(config.trigger_prefix):]
                 reply = hooks.on_trigger(timestamp, config.network, reply_to, message.sender, text_without_prefix)
-                if reply:
-                    msgsplitter[reply_to] = message_generator("PRIVMSG", reply_to, config.reply_prefix, reply['text'], conn.headerlen)
-                    msgpart = next(msgsplitter[reply_to])
-                    logger.info("-> {} : {}".format(reply_to, msgpart[msgpart.find(":")+1:]))
-                    hooks.on_send_privmsg(timestamp, config.network, reply_to, config.nick, msgpart[msgpart.find(":")+1:])
-                    conn.send(msgpart)
+            if reply:
+                commands[reply_to] = reply['command']
+                msgsplitter[reply_to] = message_generator("PRIVMSG", reply_to, config.reply_prefix, reply['text'], conn.headerlen)
+                command = reply['command']
+                msgpart = next(msgsplitter[reply_to])
             if text == "more":
                 try:
+                    command = commands[reply_to]
                     msgpart = next(msgsplitter[reply_to])
                 except:
                     pass
                 else:
                     logger.info("{} -> {} : {}".format(message.sender.nick, target, text))
-                    logger.info("-> {} : {}".format(reply_to, msgpart[msgpart.find(":")+1:]))
+            if msgpart:
+                logger.info("-> {} : {}".format(reply_to, msgpart[msgpart.find(":")+1:]))
+                if command != 'searchlog':
+                    hooks.on_privmsg(timestamp, config.network, reply_to, message.sender, text)
                     hooks.on_send_privmsg(timestamp, config.network, reply_to, config.nick, msgpart[msgpart.find(":")+1:])
-                    conn.send(msgpart)
+                conn.send(msgpart)
+            else:
+                hooks.on_privmsg(timestamp, config.network, reply_to, message.sender, text)
 
         def messages_with_default_handling():
             for message in conn.recv_messages():

--- a/pladder/irc/client.py
+++ b/pladder/irc/client.py
@@ -59,7 +59,7 @@ def run_client(config, hooks):
                 text_without_prefix = text[len(config.trigger_prefix):]
                 reply = hooks.on_trigger(timestamp, config.network, reply_to, message.sender, text_without_prefix)
                 if reply:
-                    msgsplitter[reply_to] = message_generator("PRIVMSG", reply_to, config.reply_prefix, reply, conn.headerlen)
+                    msgsplitter[reply_to] = message_generator("PRIVMSG", reply_to, config.reply_prefix, reply['text'], conn.headerlen)
                     msgpart = next(msgsplitter[reply_to])
                     logger.info("-> {} : {}".format(reply_to, msgpart[msgpart.find(":")+1:]))
                     hooks.on_send_privmsg(timestamp, config.network, reply_to, config.nick, msgpart[msgpart.find(":")+1:])

--- a/pladder/script.py
+++ b/pladder/script.py
@@ -154,7 +154,7 @@ def eval_call(bindings, context, call):
     result = apply_call(context, command, command_name, arguments)
     if command.parseoutput and result.find("[")>=0:
         result = interpret(bindings, context, "echo " + result)
-    return result
+    return result, command.command_name
 
 
 def lookup_command(bindings, command_name):


### PR DESCRIPTION
Avoid logging calls and replies to "searchlog".
Change type of command reply to a dictionary from string to string, so that additional information (command name, in this case) can be sent back to the client.