### PR TITLE
Add implicit append of arguments when command expects just 1 argument

### DIFF
--- a/pladder/plugins/userdef.py
+++ b/pladder/plugins/userdef.py
@@ -57,7 +57,11 @@ class UserdefCommands(CommandGroup):
 
         def exec_command(context: Context, *args: str) -> str:
             if len(command.params) != len(args):
-                raise ScriptError(f"{command.name} takes {len(command.params)} arguments, got {len(args)}")
+                # special case when the command expects 1 argument: just append the arguments together
+                if len(command.params) == 1 and len(args) > 1:
+                    args = [" ".join(args)]
+                else:
+                    raise ScriptError(f"{command.name} takes {len(command.params)} arguments, got {len(args)}")
             new_env = dict(zip(command.params, args))
             subcontext = context._replace(environment=new_env)
             result, _display_name = interpret(subcontext, command.script)


### PR DESCRIPTION
The reason is to add ergonomics to common patterns so that:
```
  ~command {text stuff here}
becomes
  ~command text stuff here

  ~command [echo stuff and [funny-stuff]]
becomes
  ~command stuff and [funny-stuff]

```
